### PR TITLE
fix windows environment check not work on mac

### DIFF
--- a/src/ConfigPath.php
+++ b/src/ConfigPath.php
@@ -43,7 +43,7 @@ class ConfigPath
      */
     public static function isWindows()
     {
-        return stripos(PHP_OS, 'win') !== false;
+        return DIRECTORY_SEPARATOR == '\\';
     }
 
     /**

--- a/tests/ConfigPathTest.php
+++ b/tests/ConfigPathTest.php
@@ -8,7 +8,7 @@ class ConfigPathTest extends TestCase
 {
     public function testHomeConfigDir()
     {
-        $this->assertTrue((boolean)preg_match('/win/i', PHP_OS) === ConfigPath::isWindows());
+        $this->assertTrue((boolean)(strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') === ConfigPath::isWindows());
     }
 
     public function testDefaultConfigFile()


### PR DESCRIPTION
mac 上打印 PHP_OS 的结果是 Darwin , 所以进了 windows 的判断，导致抛错了